### PR TITLE
feat: responsive navbar with scroll hide

### DIFF
--- a/client/src/components/layout/TopNav.jsx
+++ b/client/src/components/layout/TopNav.jsx
@@ -1,15 +1,48 @@
-import { Bell, Menu } from 'lucide-react';
+import {
+  Bell,
+  Menu,
+  Home,
+  BookOpenText,
+  Code2,
+  ListChecks,
+  User as UserIcon,
+} from 'lucide-react';
 import { Avatar, Dropdown } from 'flowbite-react';
 import ThemeToggle from '../../theme/ThemeToggle.jsx';
 import { Button } from '../ui/Button.jsx';
 import { Input } from '../ui/Input.jsx';
 import { Link } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
+import { useEffect, useState } from 'react';
 import { signoutSuccess } from '../../redux/user/userSlice';
+
+const navItems = [
+  { href: '/', label: 'Home', icon: Home },
+  { href: '/tutorials', label: 'Tutorials', icon: BookOpenText },
+  { href: '/tryit', label: 'Code Editor', icon: Code2 },
+  { href: '/quizzes', label: 'Quizzes', icon: ListChecks },
+  { href: '/profile', label: 'Profile', icon: UserIcon },
+];
 
 export default function TopNav({ onMenuClick }) {
   const { currentUser } = useSelector((state) => state.user);
   const dispatch = useDispatch();
+  const [hidden, setHidden] = useState(false);
+
+  useEffect(() => {
+    let lastY = window.scrollY;
+    const onScroll = () => {
+      const currentY = window.scrollY;
+      if (currentY > lastY && currentY > 50) {
+        setHidden(true);
+      } else {
+        setHidden(false);
+      }
+      lastY = currentY;
+    };
+    window.addEventListener('scroll', onScroll);
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
 
   const handleSignout = async () => {
     try {
@@ -21,8 +54,12 @@ export default function TopNav({ onMenuClick }) {
   };
 
   return (
-    <header className="sticky top-0 z-40 border-b bg-white/80 backdrop-blur dark:bg-gray-900/80">
-      <div className="flex h-16 items-center gap-4 px-4">
+    <header
+      className={`sticky top-0 z-40 border-b bg-white/80 backdrop-blur transition-transform dark:bg-gray-900/80 ${
+        hidden ? '-translate-y-full' : 'translate-y-0'
+      }`}
+    >
+      <div className="flex h-16 w-full items-center gap-4 px-4">
         <Button
           variant="ghost"
           size="sm"
@@ -32,10 +69,23 @@ export default function TopNav({ onMenuClick }) {
         >
           <Menu className="h-5 w-5" />
         </Button>
-        <a href="#" className="font-semibold">
+        <a href="/" className="font-semibold">
           ScientistShield
         </a>
-        <div className="flex flex-1 items-center justify-end gap-2">
+        <nav className="hidden items-center gap-1 md:flex">
+          {navItems.map(({ href, label, icon: Icon }) => (
+            <Link
+              key={label}
+              to={href}
+              aria-label={label}
+              className="flex items-center gap-1 rounded-md p-2 text-sm font-medium text-gray-700 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-800"
+            >
+              <Icon className="h-5 w-5" aria-hidden="true" />
+              <span className="hidden lg:inline">{label}</span>
+            </Link>
+          ))}
+        </nav>
+        <div className="ml-auto flex items-center justify-end gap-2">
           <div className="hidden w-full max-w-xs md:block">
             <Input type="search" placeholder="Search..." aria-label="Search" />
           </div>


### PR DESCRIPTION
## Summary
- enhance top navigation with icons linking to Home, Tutorials, Code Editor, Quizzes, and Profile
- add scroll-aware hide/show behavior for the sticky header

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68c780efdb44832da96e91771a5c8105